### PR TITLE
Fixed busted URL in the Testing section of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,7 +789,7 @@ you find any mistakes or typos.
 
 ## <a name='testing'>Testing</a>
 
-  - Use [busted](olivinelabs.com/busted) and write lots of tests in a /spec 
+  - Use [busted](http://olivinelabs.com/busted) and write lots of tests in a /spec 
     folder. Separate tests by module.
   - Use descriptive `describe` and `it` blocks so it's obvious to see what
     precisely is failing.


### PR DESCRIPTION
Without `http://`, GitHub assumes `olivinelabs.com/busted` is a file in the repository. Adding `http://` fixes the issue.